### PR TITLE
Add build.gradle for gradle building. This doesn't attempt to run tests ...

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,38 @@
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+
+    dependencies {
+        classpath 'com.android.tools.build:gradle:0.6.+'
+    }
+}
+
+apply plugin: 'android-library'
+
+repositories {
+    mavenCentral()
+}
+
+android {
+    compileSdkVersion 18
+    buildToolsVersion "18.1.0"
+
+    defaultConfig {
+        minSdkVersion 14
+        targetSdkVersion 17
+    }
+
+    sourceSets {
+        main {
+            manifest.srcFile 'AndroidManifest.xml'
+            java.srcDirs = ['src']
+            resources.srcDirs = ['src']
+            res.srcDirs = ['res']
+        }
+    }
+}
+
+dependencies {
+    compile 'com.google.guava:guava:14.0.+'
+}


### PR DESCRIPTION
...or the example - this is just a bare minimum to get people started. Also ignores the packaged version of guava in favor of a remote dependency, in the gradle style
