### PR TITLE
Added getter for spring looper

### DIFF
--- a/rebound-core/src/main/java/com/facebook/rebound/BaseSpringSystem.java
+++ b/rebound-core/src/main/java/com/facebook/rebound/BaseSpringSystem.java
@@ -189,6 +189,10 @@ public class BaseSpringSystem {
   public void removeAllListeners() {
     mListeners.clear();
   }
+  
+  public SpringLooper getSpringLooper(){
+      return mSpringLooper;
+  }
 }
 
 


### PR DESCRIPTION
Straightforward use case:

1.  Activity with springs.  
2.  Pause activity.  
3.  NPE's everywhere :'-(

Use to pause springs that shouldn't be running when Activity is paused.  Simply use onPause and onResume from Activity lifecycle to calls start/stop on looper. No more tears.