### PR TITLE
Update the gradle version and new JDK issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:1.2.3'
+    classpath 'com.android.tools.build:gradle:2.1.2'
   }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip

--- a/rebound-android-playground/src/main/java/com/facebook/rebound/playground/examples/SimpleExample.java
+++ b/rebound-android-playground/src/main/java/com/facebook/rebound/playground/examples/SimpleExample.java
@@ -69,11 +69,13 @@ public class SimpleExample extends FrameLayout {
 
   @Override
   protected void onAttachedToWindow() {
+    super.onAttachedToWindow();
     mScaleSpring.addListener(mSpringListener);
   }
 
   @Override
   protected void onDetachedFromWindow() {
+    super.onDetachedFromWindow();
     mScaleSpring.removeListener(mSpringListener);
   }
 

--- a/rebound-core/build.gradle
+++ b/rebound-core/build.gradle
@@ -1,4 +1,6 @@
 apply plugin: 'java'
+targetCompatibility = '1.7'
+sourceCompatibility = '1.7'
 
 dependencies {
     testCompile files(


### PR DESCRIPTION
It was not able to compile with new gradle version and also JDK 8. 
So the gradle version is updated and lint issue is solved to remove the gradle issue.

With this patch it is possible to compile with JDK8 also (however it is uses JDK7 mode because of com.facebook.rebound.SynchronousLooper)
